### PR TITLE
Add push trigger and workflow dispatch inputs to semantic release wor…

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -41,6 +41,24 @@
 name: Semantic Release (Reusable)
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - 'LICENSE'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
   workflow_call:
     inputs:
       bump:


### PR DESCRIPTION
…kflow
This pull request updates the `.github/workflows/semantic-release.yaml` workflow configuration to improve automation and flexibility for semantic releases. The most important changes are grouped below:

Trigger configuration improvements:

* The workflow is now triggered automatically on pushes to the `main` branch, excluding changes to documentation files (`**.md`), `.gitignore`, and `LICENSE`, ensuring releases are only created for relevant code changes.

Manual workflow enhancements:

* The `workflow_dispatch` event now includes a `bump` input with selectable options (`patch`, `minor`, `major`), allowing users to manually specify the version bump type when triggering the workflow.