### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/slack-pr-events.yaml
+++ b/.github/workflows/slack-pr-events.yaml
@@ -1,4 +1,6 @@
 name: Slack Pull Request Events
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/CalebSargeant/reusable-workflows/security/code-scanning/14](https://github.com/CalebSargeant/reusable-workflows/security/code-scanning/14)

To fix this problem, an explicit `permissions` block should be added either at the workflow level (recommended, as it applies to all jobs unless overridden), or specifically to the `slack_notification` job. The workflow uses the `github.token` primarily for read operations (reading PR events and details), so the minimal starting permission is `contents: read`. If you later expand the workflow to require additional write access (e.g., to issues or PRs), add only the specific permission required.

The change should be made at the top level of the workflow YAML, just below the `name:` field and above the `on:` block, by adding:
```yaml
permissions:
  contents: read
```
No additional imports or logic changes are needed—just this change to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
