### PR TITLE
Fix/pre commit hooks workflow

### DIFF
--- a/.github/workflows/hooks-ci.yml
+++ b/.github/workflows/hooks-ci.yml
@@ -94,7 +94,7 @@ jobs:
           sudo apt-get update -y || true
           sudo apt-get install -y cloc || true
           pip install radon || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -134,7 +134,7 @@ jobs:
           sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt || true
           # Install actionlint
           curl -sSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz | sudo tar -xz -C /usr/local/bin actionlint || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -173,7 +173,7 @@ jobs:
           curl -sSL -o /tmp/shfmt "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
           sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt || true
           curl -sSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz | sudo tar -xz -C /usr/local/bin actionlint || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -201,7 +201,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip || true
           pip install black isort flake8 mypy || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -226,7 +226,7 @@ jobs:
       - name: Install Node tooling
         run: |
           npm i -g prettier eslint typescript || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -252,7 +252,7 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash || true
           curl -sSL https://aquasecurity.github.io/tfsec/master/install.sh | bash || true
           pip install checkov || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -275,7 +275,7 @@ jobs:
         run: |
           curl -sSL https://raw.githubusercontent.com/hadolint/hadolint/master/install.sh | sudo bash -s -- -b /usr/local/bin
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -304,7 +304,7 @@ jobs:
         run: |
           pip install pip-licenses || true
           npm i -g license-checker || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -328,7 +328,7 @@ jobs:
           sudo apt-get update -y || true
           sudo apt-get install -y cloc || true
           pip install radon || true
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -350,7 +350,7 @@ jobs:
       - name: Install performance tooling
         run: |
           echo "No special tooling required"
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: calebsargeant/pre-commit-hooks@v1.1.0
+      - uses: calebsargeant/pre-commit-hooks@ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f # v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'

--- a/.github/workflows/hooks-ci.yml
+++ b/.github/workflows/hooks-ci.yml
@@ -94,7 +94,7 @@ jobs:
           sudo apt-get update -y || true
           sudo apt-get install -y cloc || true
           pip install radon || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -134,7 +134,7 @@ jobs:
           sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt || true
           # Install actionlint
           curl -sSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz | sudo tar -xz -C /usr/local/bin actionlint || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -173,7 +173,7 @@ jobs:
           curl -sSL -o /tmp/shfmt "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
           sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt || true
           curl -sSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz | sudo tar -xz -C /usr/local/bin actionlint || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           fail_on_high_severity: ${{ inputs.fail_on_high_severity }}
@@ -201,7 +201,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip || true
           pip install black isort flake8 mypy || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -226,7 +226,7 @@ jobs:
       - name: Install Node tooling
         run: |
           npm i -g prettier eslint typescript || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -252,7 +252,7 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash || true
           curl -sSL https://aquasecurity.github.io/tfsec/master/install.sh | bash || true
           pip install checkov || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -275,7 +275,7 @@ jobs:
         run: |
           curl -sSL https://raw.githubusercontent.com/hadolint/hadolint/master/install.sh | sudo bash -s -- -b /usr/local/bin
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -304,7 +304,7 @@ jobs:
         run: |
           pip install pip-licenses || true
           npm i -g license-checker || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -328,7 +328,7 @@ jobs:
           sudo apt-get update -y || true
           sudo apt-get install -y cloc || true
           pip install radon || true
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -350,7 +350,7 @@ jobs:
       - name: Install performance tooling
         run: |
           echo "No special tooling required"
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: calebsargeant/pre-commit-hooks@1.1.0
+      - uses: calebsargeant/pre-commit-hooks@v1.1.0
         with:
           stage: ${{ inputs.stage }}
           run_file_quality: 'false'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/calebsargeant/pre-commit-hooks
-    rev: v1.1.0
+    rev: v1.2.0
     hooks:
       - id: all


### PR DESCRIPTION
This pull request updates the version of the `calebsargeant/pre-commit-hooks` used in both the GitHub Actions workflow and the pre-commit configuration. The main goal is to ensure consistency and to use the latest features and fixes from the pre-commit hooks repository.

Dependency updates:

* Updated the `calebsargeant/pre-commit-hooks` action in `.github/workflows/hooks-ci.yml` to use a specific commit hash (`ee518abc8c091b1cbd72dfd0a7bfc09edd0cab0f`) instead of the generic `v1.1.0` tag, ensuring reproducibility and clarity about the exact code version being used. [[1]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L97-R97) [[2]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L137-R137) [[3]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L176-R176) [[4]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L204-R204) [[5]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L229-R229) [[6]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L255-R255) [[7]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L278-R278) [[8]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L307-R307) [[9]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L331-R331) [[10]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L353-R353) [[11]](diffhunk://#diff-566cdf067f66a0db190a6d38a1cef9124317e934c6e54aea480c667ff3854bb6L372-R372)
* Updated the `rev` field for `calebsargeant/pre-commit-hooks` in `.pre-commit-config.yaml` from `v1.1.0` to `v1.2.0`, ensuring the latest version of the hooks is used for local development and CI.