### PR TITLE
fix: add missing tags output configuration to Docker Bake workflow

### DIFF
--- a/.github/workflows/docker-bake-ghcr.yaml
+++ b/.github/workflows/docker-bake-ghcr.yaml
@@ -140,6 +140,7 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=${{ github.workflow }}
             *.cache-to=type=gha,mode=max,scope=${{ github.workflow }}
+            *.tags=${{ steps.meta.outputs.tags }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REGISTRY: ${{ inputs.registry }}


### PR DESCRIPTION
This pull request makes a minor update to the Docker build workflow configuration. The change ensures that Docker image tags generated by the metadata step are correctly passed to the build process.

* Workflow configuration: Added the `*.tags` parameter to the Docker build arguments in `.github/workflows/docker-bake-ghcr.yaml`, allowing image tags from the metadata step to be used during the build.