### PR TITLE
fix: remove unused tag processing step from Docker Bake workflow

### DIFF
--- a/.github/workflows/docker-bake-ghcr.yaml
+++ b/.github/workflows/docker-bake-ghcr.yaml
@@ -131,15 +131,6 @@ jobs:
         run: |
           echo "full_name=${{ github.repository_owner }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare tags for bake
-        id: bake-tags
-        run: |
-          TAGS="${{ steps.meta.outputs.tags }}"
-          # Convert newline-separated tags to JSON array format
-          TAGS_JSON=$(echo "$TAGS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "tags=${TAGS_JSON}" >> "$GITHUB_OUTPUT"
-          echo "Tags for bake: ${TAGS_JSON}"
-
       - name: Build with Docker Bake
         uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
         with:
@@ -149,7 +140,6 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=${{ github.workflow }}
             *.cache-to=type=gha,mode=max,scope=${{ github.workflow }}
-            *.tags=${{ steps.bake-tags.outputs.tags }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REGISTRY: ${{ inputs.registry }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the Docker workflow configuration by removing the step that prepares Docker image tags for the bake process. The build process no longer uses the custom tags generated by this step.

Workflow configuration simplification:

* Removed the `Prepare tags for bake` step, which converted tags to a JSON array for Docker Bake, from `.github/workflows/docker-bake-ghcr.yaml`.
* Eliminated the use of the custom tags output (`*.tags=${{ steps.bake-tags.outputs.tags }}`) in the Docker Bake configuration.