### PR TITLE
fix: normalize image name processing in Docker Bake workflow

### DIFF
--- a/.github/workflows/docker-bake-ghcr.yaml
+++ b/.github/workflows/docker-bake-ghcr.yaml
@@ -107,12 +107,19 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version: ${VERSION}"
 
+      - name: Set image name
+        id: image
+        run: |
+          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_LOWER=$(echo "${{ inputs.image_name }}" | tr '[:upper:]' '[:lower:]')
+          echo "full_name=${OWNER_LOWER}/${IMAGE_LOWER}" >> "$GITHUB_OUTPUT"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
-            ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
+            ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -125,11 +132,6 @@ jobs:
           labels: |
             org.opencontainers.image.title=${{ inputs.image_name }}
             org.opencontainers.image.description=${{ github.repository }} ${{ inputs.image_name }}
-
-      - name: Set image name
-        id: image
-        run: |
-          echo "full_name=${{ github.repository_owner }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Build with Docker Bake
         uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
@@ -150,7 +152,7 @@ jobs:
         if: inputs.enable_sbom && inputs.push && github.event_name != 'pull_request'
         uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
         with:
-          image: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ steps.version.outputs.version }}
+          image: ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
           format: spdx-json
           output-file: sbom.spdx.json
 
@@ -167,11 +169,11 @@ jobs:
         run: |
           echo "### Docker Image Built and Pushed :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ inputs.registry }}/${{ steps.image.outputs.full_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Platforms:** \`${{ inputs.platforms }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing Docker images to ensure consistent and lowercase image naming throughout the workflow. The main change is the introduction of a dedicated step to set the image name in lowercase, which is then used in all subsequent steps to avoid issues with case sensitivity and to simplify references.

**Image naming consistency:**

* Added a new step to set the Docker image name in lowercase and output it as `full_name`, ensuring consistency across the workflow.
* Updated all references to the image name in the workflow to use the new `full_name` output, including in the Docker metadata, SBOM generation, summary output, and pull command instructions. [[1]](diffhunk://#diff-eddb1cfc892ab1b50cc6a04d5b49f6d348183e3d1c23b102a83a39c16cfb65daR110-R122) [[2]](diffhunk://#diff-eddb1cfc892ab1b50cc6a04d5b49f6d348183e3d1c23b102a83a39c16cfb65daL153-R155) [[3]](diffhunk://#diff-eddb1cfc892ab1b50cc6a04d5b49f6d348183e3d1c23b102a83a39c16cfb65daL170-R178)

**Workflow simplification:**

* Removed a redundant step that previously set the image name, consolidating this logic into the new lowercase step.