### PR TITLE
fix: update semantic-release configuration in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,57 +1,29 @@
 [tool.semantic_release]
-version_toml = ["pyproject.toml:tool.semantic_release.version"]
-version_variables = []
+version_variables = ["pyproject.toml:tool.semantic_release.version"]
 build_command = ""
-commit_message = "chore(release): {version}"
-commit_parser = "angular"
-logging_use_named_masks = false
 major_on_zero = true
-allow_zero_version = true
-no_git_verify = false
-tag_format = "{version}"
+tag_format = "v{version}"
+
+# Current version (will be updated by semantic-release)
+version = "1.0.25"
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"
 prerelease = false
 
+[tool.semantic_release.branches.staging]
+match = "staging"
+prerelease = true
+prerelease_token = "rc"
+
 [tool.semantic_release.changelog]
-template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 
-[tool.semantic_release.changelog.environment]
-block_start_string = "{%"
-block_end_string = "%}"
-variable_start_string = "{{"
-variable_end_string = "}}"
-comment_start_string = "{#"
-comment_end_string = "#}"
-trim_blocks = false
-lstrip_blocks = false
-newline_sequence = "\n"
-keep_trailing_newline = false
-extensions = []
-autoescape = true
-
-[tool.semantic_release.commit_author]
-env = "GIT_COMMIT_AUTHOR"
-default = "semantic-release <semantic-release>"
-
 [tool.semantic_release.commit_parser_options]
-allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "style", "refactor", "test"]
+allowed_tags = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.remote]
-name = "origin"
 type = "github"
-ignore_token_for_push = false
-
-[tool.semantic_release.publish]
-dist_glob_patterns = ["dist/*"]
-upload_to_vcs_release = true
-
-[project]
-name = "reusable-workflows"
-version = "1.0.23"
-description = "Reusable GitHub Actions workflows"


### PR DESCRIPTION
- Added staging branch support for prerelease versions with `rc` token.
- Updated `version_variables` and `tag_format`.
- Removed unused settings to simplify the configuration file.