### PR TITLE
Fix/docker bake permissions

### DIFF
--- a/.github/workflows/docker-bake-ghcr.yaml
+++ b/.github/workflows/docker-bake-ghcr.yaml
@@ -320,6 +320,9 @@ jobs:
     name: Container Build (CI)
     if: github.event_name == 'pull_request' && inputs.promote_pr_number == ''
     runs-on: ${{ inputs.runner }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     outputs:
       version: ${{ steps.version.outputs.version }}
       image: ${{ steps.image.outputs.full_name }}

--- a/.github/workflows/docker-bake-ghcr.yaml
+++ b/.github/workflows/docker-bake-ghcr.yaml
@@ -414,6 +414,8 @@ jobs:
           targets: ${{ inputs.bake_target }}
           push: ${{ inputs.push }}
           set: |
+            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
+            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:latest
             *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}
             *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
             *.cache-to=type=gha,mode=max,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}


### PR DESCRIPTION
This pull request introduces improvements to the Docker build workflow by adding build concurrency controls and ensuring that built images are tagged consistently. These changes help prevent overlapping builds and make image versioning more predictable.

**Workflow enhancements:**

* Added a `concurrency` group to the `Container Build (CI)` job in `.github/workflows/docker-bake-ghcr.yaml` to prevent simultaneous builds for the same workflow and reference, and to cancel any in-progress builds when a new one is triggered.

**Image tagging improvements:**

* Updated the Docker build step to add both versioned and `latest` tags to built images, ensuring images are always tagged with the current version and as `latest` in the registry.