### PR TITLE
feat: add Docker Bake CI workflow and refactor existing workflows

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -1,0 +1,212 @@
+name: Docker Bake CI
+
+# Dedicated workflow for PR container builds with path filtering
+# This runs on pull requests and skips builds when only non-container files change
+
+on:
+  workflow_call:
+    inputs:
+      container_paths:
+        description: 'Paths that trigger container builds (multiline string, one glob pattern per line). Uses dorny/paths-filter syntax.'
+        required: false
+        type: string
+        default: |
+          **
+          !.github/**
+          !*.md
+          !docs/**
+          !LICENSE
+          !.gitignore
+      bake_file:
+        description: 'Path to docker-bake file'
+        required: false
+        type: string
+        default: 'docker-bake.hcl'
+      bake_target:
+        description: 'Docker Bake target to build'
+        required: false
+        type: string
+        default: 'default'
+      push_target:
+        description: 'Docker Bake target for push (if different from build target)'
+        required: false
+        type: string
+        default: ''
+      image_name:
+        description: 'Docker image name (without registry/org prefix). Defaults to bake_target if not specified.'
+        required: false
+        type: string
+        default: ''
+      platforms:
+        description: 'Target platforms (comma-separated)'
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64'
+      push:
+        description: 'Push images to registry'
+        required: false
+        type: boolean
+        default: true
+      registry:
+        description: 'Container registry'
+        required: false
+        type: string
+        default: 'ghcr.io'
+      runner:
+        description: 'GitHub runner to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      force_version:
+        description: 'Force specific version (overrides automatic detection)'
+        required: false
+        type: string
+        default: ''
+      buildx_vars:
+        description: 'Additional environment variables for docker/bake-action (lines like KEY=VALUE)'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      version:
+        description: 'The version tag that was built'
+        value: ${{ jobs.ci-build.outputs.version }}
+      image:
+        description: 'The full image name (without tag)'
+        value: ${{ jobs.ci-build.outputs.image }}
+      image_with_tag:
+        description: 'The full image name with tag'
+        value: ${{ jobs.ci-build.outputs.image_with_tag }}
+      build_skipped:
+        description: 'Whether the build was skipped due to path filtering'
+        value: ${{ jobs.check-changes.outputs.should_skip }}
+    secrets:
+      registry_username:
+        required: false
+      registry_password:
+        required: false
+
+jobs:
+  check-changes:
+    name: Check Changed Files
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      pull-requests: read
+    outputs:
+      container_changed: ${{ steps.filter.outputs.container }}
+      should_skip: ${{ steps.filter.outputs.container != 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check for container-related changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            container:
+              ${{ inputs.container_paths }}
+
+      - name: Build decision
+        run: |
+          if [ "${{ steps.filter.outputs.container }}" == "true" ]; then
+            echo "✓ Container-related files changed - build will proceed"
+          else
+            echo "ℹ️ No container-related files changed - build will be skipped"
+            echo ""
+            echo "To trigger a build, modify files matching the container_paths filter."
+            echo "Current filter patterns:"
+            echo "${{ inputs.container_paths }}" | sed 's/^/  /'
+          fi
+
+  ci-build:
+    name: Container Build (CI)
+    needs: check-changes
+    if: needs.check-changes.outputs.container_changed == 'true'
+    runs-on: ${{ inputs.runner }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      image: ${{ steps.image.outputs.full_name }}
+      image_with_tag: ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+          buildkitd-flags: --debug
+
+      - name: Log in to Container Registry
+        if: inputs.push
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION="pr-${{ github.event.pull_request.number }}"
+
+          # Override with force_version if provided
+          if [[ -n "${{ inputs.force_version }}" ]]; then
+            VERSION="${{ inputs.force_version }}"
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building version: ${VERSION}"
+
+      - name: Set image name
+        id: image
+        run: |
+          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # Use image_name if provided, otherwise fall back to bake_target
+          IMAGE_NAME="${{ inputs.image_name }}"
+          if [ -z "${IMAGE_NAME}" ]; then
+            IMAGE_NAME="${{ inputs.bake_target }}"
+          fi
+          IMAGE_LOWER=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
+          echo "full_name=${OWNER_LOWER}/${IMAGE_LOWER}" >> "$GITHUB_OUTPUT"
+
+      - name: Export build variables
+        if: inputs.buildx_vars != ''
+        run: |
+          # Export each KEY=VALUE pair as environment variable for docker/bake-action
+          # Bake automatically picks up env vars matching variable names in the HCL file
+          printf '%s\n' "${{ inputs.buildx_vars }}" >> "$GITHUB_ENV"
+
+      - name: Build with Docker Bake
+        uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
+        with:
+          files: |
+            ${{ inputs.bake_file }}
+          targets: ${{ inputs.bake_target }}
+          push: ${{ inputs.push }}
+          set: |
+            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
+            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:latest
+            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}
+            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
+            *.cache-to=type=gha,mode=max,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
+            *.cache-to=type=inline
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ steps.image.outputs.full_name }}
+          PLATFORMS: ${{ inputs.platforms }}

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -69,16 +69,16 @@ on:
         default: ''
     outputs:
       version:
-        description: 'The version tag that was built'
+        description: 'The version tag that was built. This will be empty if build_skipped == "true" (no container build was run).'
         value: ${{ jobs.ci-build.outputs.version }}
       image:
-        description: 'The full image name (without tag)'
+        description: 'The full image name (without tag). This will be empty if build_skipped == "true" (no container build was run).'
         value: ${{ jobs.ci-build.outputs.image }}
       image_with_tag:
-        description: 'The full image name with tag'
+        description: 'The full image name with tag. This will be empty if build_skipped == "true" (no container build was run).'
         value: ${{ jobs.ci-build.outputs.image_with_tag }}
       build_skipped:
-        description: 'Whether the build was skipped due to path filtering'
+        description: 'Whether the build was skipped due to path filtering. Callers should check this before using version/image outputs.'
         value: ${{ jobs.check-changes.outputs.should_skip }}
     secrets:
       registry_username:

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -201,9 +201,9 @@ jobs:
           set: |
             *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
             *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:latest
-            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}
-            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
-            *.cache-to=type=gha,mode=max,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
+            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name || inputs.bake_target }}
+            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name || inputs.bake_target }}-${{ github.ref_name }}
+            *.cache-to=type=gha,mode=max,scope=buildkit-${{ inputs.image_name || inputs.bake_target }}-${{ github.ref_name }}
             *.cache-to=type=inline
         env:
           VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,13 +1,13 @@
 name: Reusable Docker Bake to GHCR
 
 # Workflow Strategy:
-#   PR opened/updated -> CI builds & pushes pr-<number> image
+#   PR opened/updated -> Use docker-bake-ci.yaml (separate workflow) to build & push pr-<number> image
 #   PR merged -> Semantic Release creates release
 #   Release published -> Checks if pr-<number> image is current:
 #     - If PR image digest matches latest: Promotes to release version (no rebuild!)
 #     - If PR image is outdated: Skips promotion and rebuilds fresh image
 #
-# Example caller workflow (simple - auto-promotion on release):
+# Example caller workflow (with separate PR and release workflows):
 #
 #   name: Docker Build
 #   on:
@@ -18,16 +18,24 @@ name: Reusable Docker Bake to GHCR
 #       types: [published]
 #
 #   jobs:
-#     docker:
+#     ci:
+#       if: github.event_name == 'pull_request'
+#       uses: your-org/reusable-workflows/.github/workflows/docker-bake-ci.yaml@main
+#       with:
+#         image_name: my-app
+#       secrets: inherit
+#
+#     release:
+#       if: github.event_name == 'release'
 #       uses: your-org/reusable-workflows/.github/workflows/docker-bake-ghcr.yaml@main
 #       with:
 #         image_name: my-app
 #       secrets: inherit
 #
-# The workflow automatically:
-#   - Builds pr-<number> images on pull request events
-#   - On release: extracts the PR number and checks if the PR image is up-to-date
-#   - Promotes PR image if current, or rebuilds if outdated
+# This workflow (docker-bake-ghcr.yaml) handles:
+#   - Release image promotion (re-tagging PR images)
+#   - Fresh builds when PR images are outdated
+#   - Manual builds via workflow_dispatch
 
 on:
   workflow_call:
@@ -100,13 +108,13 @@ on:
     outputs:
       version:
         description: 'The version tag that was built or promoted'
-        value: ${{ jobs.ci-build.outputs.version || jobs.promote.outputs.version || jobs.build.outputs.version }}
+        value: ${{ jobs.promote.outputs.version || jobs.build.outputs.version }}
       image:
         description: 'The full image name (without tag)'
-        value: ${{ jobs.ci-build.outputs.image || jobs.promote.outputs.image || jobs.build.outputs.image }}
+        value: ${{ jobs.promote.outputs.image || jobs.build.outputs.image }}
       image_with_tag:
         description: 'The full image name with tag'
-        value: ${{ jobs.ci-build.outputs.image_with_tag || jobs.promote.outputs.image_with_tag || jobs.build.outputs.image_with_tag }}
+        value: ${{ jobs.promote.outputs.image_with_tag || jobs.build.outputs.image_with_tag }}
       pr_number:
         description: 'The PR number that was promoted (if applicable)'
         value: ${{ jobs.get-pr-number.outputs.pr_number }}
@@ -316,115 +324,6 @@ jobs:
 
             core.setFailed(`Could not find merged PR for commit ${commitSha}. Commit message: ${commit.message.split('\n')[0]}`);
 
-  ci-build:
-    name: Container Build (CI)
-    if: github.event_name == 'pull_request' && inputs.promote_pr_number == ''
-    runs-on: ${{ inputs.runner }}
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      image: ${{ steps.image.outputs.full_name }}
-      image_with_tag: ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
-          buildkitd-flags: --debug
-
-      - name: Log in to Container Registry
-        if: inputs.push
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Determine version
-        id: version
-        run: |
-          VERSION="latest"
-          EVENT_NAME="${{ github.event_name }}"
-          REF="${{ github.ref }}"
-
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]] && [[ -n "${{ github.event.inputs.version || '' }}" ]]; then
-            VERSION="${{ github.event.inputs.version }}"
-          elif [[ "${EVENT_NAME}" == "release" ]]; then
-            VERSION="${{ github.event.release.tag_name }}"
-          elif [[ "${REF}" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          elif [[ "${EVENT_NAME}" == "repository_dispatch" ]]; then
-            VERSION="${{ github.event.client_payload.version || 'latest' }}"
-          elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            VERSION="pr-${{ github.event.pull_request.number }}"
-          elif [[ "${REF}" == "refs/heads/main" ]] || [[ "${REF}" == "refs/heads/master" ]]; then
-            VERSION="latest"
-          else
-            BRANCH="${GITHUB_REF#refs/heads/}"
-            VERSION="${BRANCH//\//-}"
-          fi
-
-          # Override with force_version if provided
-          if [[ -n "${{ inputs.force_version }}" ]]; then
-            VERSION="${{ inputs.force_version }}"
-          fi
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Building version: ${VERSION}"
-
-      - name: Set image name
-        id: image
-        run: |
-          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          # Use image_name if provided, otherwise fall back to bake_target
-          IMAGE_NAME="${{ inputs.image_name }}"
-          if [ -z "${IMAGE_NAME}" ]; then
-            IMAGE_NAME="${{ inputs.bake_target }}"
-          fi
-          IMAGE_LOWER=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
-          echo "full_name=${OWNER_LOWER}/${IMAGE_LOWER}" >> "$GITHUB_OUTPUT"
-
-      - name: Export build variables
-        if: inputs.buildx_vars != ''
-        run: |
-          # Export each KEY=VALUE pair as environment variable for docker/bake-action
-          # Bake automatically picks up env vars matching variable names in the HCL file
-          printf '%s\n' "${{ inputs.buildx_vars }}" >> "$GITHUB_ENV"
-
-      - name: Build with Docker Bake
-        uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
-        with:
-          files: |
-            ${{ inputs.bake_file }}
-          targets: ${{ inputs.bake_target }}
-          push: ${{ inputs.push }}
-          set: |
-            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
-            *.tags=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:latest
-            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}
-            *.cache-from=type=gha,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
-            *.cache-to=type=gha,mode=max,scope=buildkit-${{ inputs.image_name }}-${{ github.ref_name }}
-            *.cache-to=type=inline
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ steps.image.outputs.full_name }}
-          PLATFORMS: ${{ inputs.platforms }}
 
   promote:
     name: Promote PR Image
@@ -725,19 +624,3 @@ jobs:
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ steps.image.outputs.full_name }}
           PLATFORMS: ${{ inputs.platforms }}
-
-#      - name: Generate SBOM
-#        if: inputs.enable_sbom && inputs.push && github.event_name != 'pull_request'
-#        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
-#        with:
-#          image: ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
-#          format: spdx-json
-#          output-file: sbom.spdx.json
-#
-#      - name: Upload SBOM
-#        if: inputs.enable_sbom && inputs.push && github.event_name != 'pull_request'
-#        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-#        with:
-#          name: sbom-${{ inputs.image_name }}
-#          path: sbom.spdx.json
-#          retention-days: 90

--- a/.github/workflows/kustomize-ci.yaml
+++ b/.github/workflows/kustomize-ci.yaml
@@ -127,12 +127,12 @@ jobs:
             kustomize build "$kustomization_dir" >> rendered-manifests.yaml
             echo "---" >> rendered-manifests.yaml
           done
-          
+
           if [ ! -s rendered-manifests.yaml ]; then
             echo "::error::No Kustomize manifests were built. Check if kustomization.yaml exists in ${{ inputs.k8s_directory }}"
             exit 1
           fi
-          
+
           echo "Successfully built Kustomize manifests"
 
       - name: 'Validate with kubeconform'
@@ -142,7 +142,7 @@ jobs:
           if [ "${{ inputs.strict_validation }}" == "true" ]; then
             STRICT_FLAG="-strict"
           fi
-          
+
           cat rendered-manifests.yaml | docker run --rm -i \
             ghcr.io/yannh/kubeconform:v0.6.7-alpine \
             $STRICT_FLAG \
@@ -157,7 +157,7 @@ jobs:
           if [[ ! "$K8S_VERSION_SHORT" =~ ^v ]]; then
             K8S_VERSION_SHORT="v${K8S_VERSION_SHORT}"
           fi
-          
+
           cat rendered-manifests.yaml | docker run --rm -i \
             zegl/kube-score:v1.19.0 \
             score - \
@@ -184,7 +184,7 @@ jobs:
             echo "✓ No changes detected in ${{ inputs.k8s_directory }}, skipping linting"
             exit 0
           fi
-          
+
           if [ "${{ needs.lint.result }}" == "success" ]; then
             echo "✓ Kustomize linting passed"
             exit 0

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -96,6 +96,11 @@ on:
         required: false
         type: string
         default: '.'
+      fetch_depth:
+        description: 'Number of commits to fetch. 0 indicates all history for all branches and tags'
+        required: false
+        type: number
+        default: 0
     outputs:
       version:
         description: "The newly released version"
@@ -148,7 +153,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 50  # Fetch enough history for semantic release to analyze commits
+          fetch-depth: ${{ inputs.fetch_depth }}  # Fetch full history by default (0) so semantic release can analyze all commits and find previous tags
           fetch-tags: true  # Explicitly fetch tags for version detection
           # Use GitHub App token, PAT, or default GITHUB_TOKEN
           token: ${{ steps.app-token.outputs.token || secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -148,7 +148,8 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 0  # Full history needed for semantic release
+          fetch-depth: 50  # Fetch enough history for semantic release to analyze commits
+          fetch-tags: true  # Explicitly fetch tags for version detection
           # Use GitHub App token, PAT, or default GITHUB_TOKEN
           token: ${{ steps.app-token.outputs.token || secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -180,13 +181,6 @@ jobs:
       - name: Force branch to workflow sha
         run: |
           git reset --hard ${{ github.sha }}
-
-      - name: Change to working directory
-        if: inputs.working_directory != '.'
-        env:
-          WORKING_DIR: ${{ inputs.working_directory }}
-        run: |
-          cd "${WORKING_DIR}"
 
       - name: Python Semantic Release
         id: release


### PR DESCRIPTION
This pull request refactors and improves the GitHub Actions workflows for Docker container builds and releases, separating concerns between pull request (PR) builds and release builds. The main change is the introduction of a dedicated workflow for PR container builds, along with simplifications and clarifications to the release workflow. It also includes minor improvements to the semantic release workflow.

**Workflow Refactoring and Separation:**

* Added a new workflow `.github/workflows/docker-ci.yaml` dedicated to building Docker images on PRs, with configurable path filtering to skip builds when only non-container files change. This workflow is reusable and outputs key build information.
* Updated the main Docker release workflow (now `.github/workflows/docker-release.yaml`, renamed from `docker-bake-ghcr.yaml`) to delegate PR builds to the new CI workflow and focus solely on release image promotion and manual builds. [[1]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540L4-R10) [[2]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540L21-R38)

**Simplification and Cleanup:**

* Removed the inlined PR build job (`ci-build`) from the release workflow, so it now only handles release image promotion and rebuilds, reducing complexity and duplication.
* Updated workflow outputs in the release workflow to reflect the removal of the PR build job, ensuring output values are correctly sourced from the appropriate jobs.
* Cleaned up commented-out SBOM generation/upload steps in the release workflow for clarity.

**Semantic Release Improvements:**

* Improved the checkout step in `.github/workflows/semantic-release.yaml` to fetch sufficient history and tags for semantic release to function reliably.
* Removed redundant working directory change logic in the semantic release workflow, simplifying the job steps.