### PR TITLE
Fix/kustomize ci mono job

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -11,12 +11,95 @@ on:
         required: false
         type: string
         default: |
-          **
-          !.github/**
-          !*.md
-          !docs/**
-          !LICENSE
-          !.gitignore
+          Dockerfile
+          Dockerfile.*
+          **/Dockerfile
+          **/Dockerfile.*
+          docker-bake.hcl
+          docker-compose*.yml
+          docker-compose*.yaml
+          .dockerignore
+          src/**
+          app/**
+          cmd/**
+          pkg/**
+          internal/**
+          lib/**
+          bin/**
+          scripts/**
+          go.mod
+          go.sum
+          package.json
+          package-lock.json
+          yarn.lock
+          pnpm-lock.yaml
+          requirements.txt
+          pyproject.toml
+          poetry.lock
+          Pipfile
+          Pipfile.lock
+          Cargo.toml
+          Cargo.lock
+          Gemfile
+          Gemfile.lock
+          *.csproj
+          *.fsproj
+          *.vbproj
+          *.sln
+          nuget.config
+          Directory.Build.props
+          Directory.Packages.props
+          global.json
+          composer.json
+          composer.lock
+          pom.xml
+          build.gradle
+          build.gradle.kts
+          settings.gradle
+          settings.gradle.kts
+          mix.exs
+          mix.lock
+          pubspec.yaml
+          pubspec.lock
+          *.go
+          *.py
+          *.js
+          *.ts
+          *.jsx
+          *.tsx
+          *.rb
+          *.rs
+          *.cs
+          *.fs
+          *.vb
+          *.sh
+          *.bash
+          *.zsh
+          *.php
+          *.java
+          *.kt
+          *.kts
+          *.scala
+          *.ex
+          *.exs
+          *.erl
+          *.hrl
+          *.swift
+          *.m
+          *.mm
+          *.c
+          *.cpp
+          *.cc
+          *.cxx
+          *.h
+          *.hpp
+          *.hxx
+          *.lua
+          *.pl
+          *.pm
+          *.r
+          *.R
+          *.dart
       bake_file:
         description: 'Path to docker-bake file'
         required: false
@@ -79,7 +162,7 @@ on:
         value: ${{ jobs.ci-build.outputs.image_with_tag }}
       build_skipped:
         description: 'Whether the build was skipped due to path filtering. Callers should check this before using version/image outputs.'
-        value: ${{ jobs.check-changes.outputs.should_skip }}
+        value: ${{ jobs.ci-build.outputs.build_skipped }}
     secrets:
       registry_username:
         required: false
@@ -87,17 +170,26 @@ on:
         required: false
 
 jobs:
-  check-changes:
-    name: Check Changed Files
+  ci-build:
+    name: Container Build (CI)
     runs-on: ${{ inputs.runner }}
-    permissions:
-      pull-requests: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     outputs:
-      container_changed: ${{ steps.filter.outputs.container }}
-      should_skip: ${{ steps.filter.outputs.container != 'true' }}
+      version: ${{ steps.version.outputs.version }}
+      image: ${{ steps.image.outputs.full_name }}
+      image_with_tag: ${{ steps.image-with-tag.outputs.image_with_tag }}
+      build_skipped: ${{ steps.filter.outputs.container != 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Check for container-related changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -119,31 +211,12 @@ jobs:
             echo "${{ inputs.container_paths }}" | sed 's/^/  /'
           fi
 
-  ci-build:
-    name: Container Build (CI)
-    needs: check-changes
-    if: needs.check-changes.outputs.container_changed == 'true'
-    runs-on: ${{ inputs.runner }}
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      image: ${{ steps.image.outputs.full_name }}
-      image_with_tag: ${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-
       - name: Set up QEMU
+        if: steps.filter.outputs.container == 'true'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
+        if: steps.filter.outputs.container == 'true'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: |
@@ -152,7 +225,7 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Log in to Container Registry
-        if: inputs.push
+        if: steps.filter.outputs.container == 'true' && inputs.push
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ inputs.registry }}
@@ -160,6 +233,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine version
+        if: steps.filter.outputs.container == 'true'
         id: version
         run: |
           VERSION="pr-${{ github.event.pull_request.number }}"
@@ -173,6 +247,7 @@ jobs:
           echo "Building version: ${VERSION}"
 
       - name: Set image name
+        if: steps.filter.outputs.container == 'true'
         id: image
         run: |
           OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
@@ -184,14 +259,21 @@ jobs:
           IMAGE_LOWER=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
           echo "full_name=${OWNER_LOWER}/${IMAGE_LOWER}" >> "$GITHUB_OUTPUT"
 
+      - name: Set image with tag
+        if: steps.filter.outputs.container == 'true'
+        id: image-with-tag
+        run: |
+          echo "image_with_tag=${{ inputs.registry }}/${{ steps.image.outputs.full_name }}:${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+
       - name: Export build variables
-        if: inputs.buildx_vars != ''
+        if: steps.filter.outputs.container == 'true' && inputs.buildx_vars != ''
         run: |
           # Export each KEY=VALUE pair as environment variable for docker/bake-action
           # Bake automatically picks up env vars matching variable names in the HCL file
           printf '%s\n' "${{ inputs.buildx_vars }}" >> "$GITHUB_ENV"
 
       - name: Build with Docker Bake
+        if: steps.filter.outputs.container == 'true'
         uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
         with:
           files: |

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -7,99 +7,99 @@ on:
   workflow_call:
     inputs:
       container_paths:
-        description: 'Paths that trigger container builds (multiline string, one glob pattern per line). Uses dorny/paths-filter syntax.'
+        description: 'Paths that trigger container builds (multiline string, one glob pattern per line with "- " prefix). Uses dorny/paths-filter syntax.'
         required: false
         type: string
         default: |
-          Dockerfile
-          Dockerfile.*
-          **/Dockerfile
-          **/Dockerfile.*
-          docker-bake.hcl
-          docker-compose*.yml
-          docker-compose*.yaml
-          .dockerignore
-          src/**
-          app/**
-          cmd/**
-          pkg/**
-          internal/**
-          lib/**
-          bin/**
-          scripts/**
-          go.mod
-          go.sum
-          package.json
-          package-lock.json
-          yarn.lock
-          pnpm-lock.yaml
-          requirements.txt
-          pyproject.toml
-          poetry.lock
-          Pipfile
-          Pipfile.lock
-          Cargo.toml
-          Cargo.lock
-          Gemfile
-          Gemfile.lock
-          *.csproj
-          *.fsproj
-          *.vbproj
-          *.sln
-          nuget.config
-          Directory.Build.props
-          Directory.Packages.props
-          global.json
-          composer.json
-          composer.lock
-          pom.xml
-          build.gradle
-          build.gradle.kts
-          settings.gradle
-          settings.gradle.kts
-          mix.exs
-          mix.lock
-          pubspec.yaml
-          pubspec.lock
-          *.go
-          *.py
-          *.js
-          *.ts
-          *.jsx
-          *.tsx
-          *.rb
-          *.rs
-          *.cs
-          *.fs
-          *.vb
-          *.sh
-          *.bash
-          *.zsh
-          *.php
-          *.java
-          *.kt
-          *.kts
-          *.scala
-          *.ex
-          *.exs
-          *.erl
-          *.hrl
-          *.swift
-          *.m
-          *.mm
-          *.c
-          *.cpp
-          *.cc
-          *.cxx
-          *.h
-          *.hpp
-          *.hxx
-          *.lua
-          *.pl
-          *.pm
-          *.r
-          *.R
-          *.dart
+          - Dockerfile
+          - Dockerfile.*
+          - '**/Dockerfile'
+          - '**/Dockerfile.*'
+          - docker-bake.hcl
+          - 'docker-compose*.yml'
+          - 'docker-compose*.yaml'
+          - .dockerignore
+          - 'src/**'
+          - 'app/**'
+          - 'cmd/**'
+          - 'pkg/**'
+          - 'internal/**'
+          - 'lib/**'
+          - 'bin/**'
+          - 'scripts/**'
+          - go.mod
+          - go.sum
+          - package.json
+          - package-lock.json
+          - yarn.lock
+          - pnpm-lock.yaml
+          - requirements.txt
+          - pyproject.toml
+          - poetry.lock
+          - Pipfile
+          - Pipfile.lock
+          - Cargo.toml
+          - Cargo.lock
+          - Gemfile
+          - Gemfile.lock
+          - '*.csproj'
+          - '*.fsproj'
+          - '*.vbproj'
+          - '*.sln'
+          - nuget.config
+          - Directory.Build.props
+          - Directory.Packages.props
+          - global.json
+          - composer.json
+          - composer.lock
+          - pom.xml
+          - build.gradle
+          - build.gradle.kts
+          - settings.gradle
+          - settings.gradle.kts
+          - mix.exs
+          - mix.lock
+          - pubspec.yaml
+          - pubspec.lock
+          - '*.go'
+          - '*.py'
+          - '*.js'
+          - '*.ts'
+          - '*.jsx'
+          - '*.tsx'
+          - '*.rb'
+          - '*.rs'
+          - '*.cs'
+          - '*.fs'
+          - '*.vb'
+          - '*.sh'
+          - '*.bash'
+          - '*.zsh'
+          - '*.php'
+          - '*.java'
+          - '*.kt'
+          - '*.kts'
+          - '*.scala'
+          - '*.ex'
+          - '*.exs'
+          - '*.erl'
+          - '*.hrl'
+          - '*.swift'
+          - '*.m'
+          - '*.mm'
+          - '*.c'
+          - '*.cpp'
+          - '*.cc'
+          - '*.cxx'
+          - '*.h'
+          - '*.hpp'
+          - '*.hxx'
+          - '*.lua'
+          - '*.pl'
+          - '*.pm'
+          - '*.r'
+          - '*.R'
+          - '*.dart'
       bake_file:
         description: 'Path to docker-bake file'
         required: false

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -105,6 +105,33 @@ on:
         required: false
         type: string
         default: ''
+      version_branch_mapping:
+        description: |
+          JSON object mapping branches to version types. Supports any number of branches.
+          Format: {"branch_name": {"type": "stable|prerelease", "identifier": "rc|beta|alpha|..."}}
+
+          Version format (opinionated):
+            - Stable: v{major}.{minor}.{patch} (e.g., v1.2.3)
+            - Prerelease: v{major}.{minor}.{patch}-{identifier}.{number} (e.g., v1.2.3-rc.1)
+
+          Examples:
+            Single stable branch:
+              {"main": {"type": "stable"}}
+
+            Two branches (stable + rc):
+              {"main": {"type": "stable"}, "staging": {"type": "prerelease", "identifier": "rc"}}
+
+            Three branches:
+              {"main": {"type": "stable"}, "staging": {"type": "prerelease", "identifier": "rc"}, "develop": {"type": "prerelease", "identifier": "alpha"}}
+
+            Four branches:
+              {"main": {"type": "stable"}, "release": {"type": "prerelease", "identifier": "rc"}, "staging": {"type": "prerelease", "identifier": "beta"}, "develop": {"type": "prerelease", "identifier": "alpha"}}
+
+          Version precedence (for auto-increment base): stable > rc > beta > alpha > dev
+          When empty string or not set, no version validation/auto-increment is performed.
+        required: false
+        type: string
+        default: ''
     outputs:
       version:
         description: 'The version tag that was built or promoted'
@@ -118,6 +145,9 @@ on:
       pr_number:
         description: 'The PR number that was promoted (if applicable)'
         value: ${{ jobs.get-pr-number.outputs.pr_number }}
+      validated_version:
+        description: 'The validated/auto-determined version (when version_branch_mapping is enabled)'
+        value: ${{ jobs.validate-version.outputs.version }}
     secrets:
       registry_username:
         required: false
@@ -125,6 +155,218 @@ on:
         required: false
 
 jobs:
+  # Validate version format matches branch type (when version_branch_mapping is enabled)
+  validate-version:
+    name: Validate Version
+    if: inputs.version_branch_mapping != ''
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      valid: ${{ steps.validate.outputs.valid }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Determine current branch
+        id: branch
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For releases, get the branch from the release target
+            BRANCH="${{ github.event.release.target_commitish }}"
+          elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
+            BRANCH="${GITHUB_REF#refs/heads/}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Current branch: $BRANCH"
+
+      - name: Parse branch mapping
+        id: mapping
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          MAPPING='${{ inputs.version_branch_mapping }}'
+
+          echo "Branch mapping: $MAPPING"
+          echo "Looking up branch: $BRANCH"
+
+          # Extract this branch's config from the JSON mapping
+          BRANCH_CONFIG=$(echo "$MAPPING" | jq -r --arg branch "$BRANCH" '.[$branch] // empty')
+
+          if [[ -z "$BRANCH_CONFIG" ]]; then
+            echo "Branch '$BRANCH' not found in mapping"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "type=" >> "$GITHUB_OUTPUT"
+            echo "identifier=" >> "$GITHUB_OUTPUT"
+          else
+            TYPE=$(echo "$BRANCH_CONFIG" | jq -r '.type')
+            IDENTIFIER=$(echo "$BRANCH_CONFIG" | jq -r '.identifier // empty')
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+            echo "identifier=$IDENTIFIER" >> "$GITHUB_OUTPUT"
+            echo "Branch config: type=$TYPE, identifier=$IDENTIFIER"
+          fi
+
+      - name: Validate version format for branch
+        id: validate
+        if: steps.mapping.outputs.found == 'true'
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          VERSION="${{ inputs.force_version }}"
+          TYPE="${{ steps.mapping.outputs.type }}"
+          IDENTIFIER="${{ steps.mapping.outputs.identifier }}"
+
+          if [[ -z "$VERSION" ]]; then
+            echo "No version provided, skipping validation"
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Validate version format matches branch type
+          if [[ "$TYPE" == "stable" ]]; then
+            # Stable branch: must be stable semver (vX.Y.Z, no prerelease)
+            if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "✓ Valid stable version for $BRANCH: $VERSION"
+              echo "valid=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Invalid version for $BRANCH branch: $VERSION"
+              echo "::error::$BRANCH branch requires stable semver (e.g., v1.2.3)"
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+          elif [[ "$TYPE" == "prerelease" ]]; then
+            # Prerelease branch: must be prerelease version (vX.Y.Z-<identifier>.N)
+            if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-${IDENTIFIER}\.[0-9]+$ ]]; then
+              echo "✓ Valid ${IDENTIFIER} version for $BRANCH: $VERSION"
+              echo "valid=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Invalid version for $BRANCH branch: $VERSION"
+              echo "::error::$BRANCH branch requires ${IDENTIFIER} semver (e.g., v1.2.3-${IDENTIFIER}.1)"
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+          else
+            echo "::error::Unknown version type '$TYPE' for branch $BRANCH"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Determine version
+        id: version
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          VERSION="${{ inputs.force_version }}"
+          MAPPING='${{ inputs.version_branch_mapping }}'
+          BRANCH_FOUND="${{ steps.mapping.outputs.found }}"
+          TYPE="${{ steps.mapping.outputs.type }}"
+          IDENTIFIER="${{ steps.mapping.outputs.identifier }}"
+
+          # If version provided and validated, use it
+          if [[ -n "$VERSION" ]]; then
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using provided version: $VERSION"
+            exit 0
+          fi
+
+          # For release events, use the release tag
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using release tag: $VERSION"
+            exit 0
+          fi
+
+          # If branch not in mapping, use branch name as version
+          if [[ "$BRANCH_FOUND" != "true" ]]; then
+            BRANCH_SAFE=$(echo "$BRANCH" | tr '/' '-')
+            echo "version=$BRANCH_SAFE" >> "$GITHUB_OUTPUT"
+            echo "Branch not in mapping, using branch name as version: $BRANCH_SAFE"
+            exit 0
+          fi
+
+          # Auto-determine next version based on branch type
+          if [[ "$TYPE" == "stable" ]]; then
+            # Get latest stable tag (vX.Y.Z without prerelease)
+            LATEST=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+            if [[ -z "$LATEST" ]]; then
+              NEXT="v0.1.0"
+            else
+              # Increment patch version
+              MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+              MINOR=$(echo "$LATEST" | cut -d. -f2)
+              PATCH=$(echo "$LATEST" | cut -d. -f3)
+              NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            fi
+            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+            echo "Auto-determined next stable version: $NEXT"
+
+          elif [[ "$TYPE" == "prerelease" ]]; then
+            # For prerelease, we need to find the appropriate base version
+            # The base is determined by finding the highest version from higher-precedence branches
+
+            # Define precedence order: stable > rc > beta > alpha > dev
+            declare -A PRECEDENCE=(["stable"]=100 ["rc"]=80 ["beta"]=60 ["alpha"]=40 ["dev"]=20)
+            CURRENT_PREC=${PRECEDENCE[$IDENTIFIER]:-10}
+
+            # Get the latest stable version as baseline
+            LATEST_STABLE=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+
+            # Also check for higher-precedence prereleases
+            # Extract all prerelease identifiers from the mapping that have higher precedence
+            HIGHER_PREC_VERSIONS=""
+            for branch_key in $(echo "$MAPPING" | jq -r 'keys[]'); do
+              branch_type=$(echo "$MAPPING" | jq -r --arg k "$branch_key" '.[$k].type')
+              branch_identifier=$(echo "$MAPPING" | jq -r --arg k "$branch_key" '.[$k].identifier // empty')
+
+              if [[ "$branch_type" == "prerelease" && -n "$branch_identifier" ]]; then
+                prec=${PRECEDENCE[$branch_identifier]:-10}
+                if (( prec > CURRENT_PREC )); then
+                  # Get latest version with this identifier
+                  latest_pre=$(git tag -l "v*-${branch_identifier}.*" | sort -V | tail -1)
+                  if [[ -n "$latest_pre" ]]; then
+                    HIGHER_PREC_VERSIONS="$HIGHER_PREC_VERSIONS $latest_pre"
+                    echo "Found higher precedence version: $latest_pre (${branch_identifier}, prec=$prec)"
+                  fi
+                fi
+              fi
+            done
+
+            # Determine the base version (highest from stable or higher-precedence prereleases)
+            if [[ -z "$LATEST_STABLE" ]]; then
+              BASE="v0.1.0"
+            else
+              # Start with next patch after stable
+              MAJOR=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f1)
+              MINOR=$(echo "$LATEST_STABLE" | cut -d. -f2)
+              PATCH=$(echo "$LATEST_STABLE" | cut -d. -f3)
+              BASE="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            fi
+
+            # Check if any higher-precedence prerelease has a higher base
+            for hpv in $HIGHER_PREC_VERSIONS; do
+              # Extract base version from prerelease (e.g., v1.2.3-rc.1 -> v1.2.3)
+              hpv_base=$(echo "$hpv" | sed 's/-[^-]*$//')
+              if [[ $(printf '%s\n' "$BASE" "$hpv_base" | sort -V | tail -1) == "$hpv_base" && "$hpv_base" != "$BASE" ]]; then
+                BASE="$hpv_base"
+                echo "Using base from higher-precedence prerelease: $BASE"
+              fi
+            done
+
+            # Find latest prerelease for this base version and identifier
+            LATEST_PRE=$(git tag -l "${BASE}-${IDENTIFIER}.*" | sort -V | tail -1)
+            if [[ -z "$LATEST_PRE" ]]; then
+              NEXT="${BASE}-${IDENTIFIER}.1"
+            else
+              PRE_NUM=$(echo "$LATEST_PRE" | grep -oE "${IDENTIFIER}\.[0-9]+" | cut -d. -f2)
+              NEXT="${BASE}-${IDENTIFIER}.$((PRE_NUM + 1))"
+            fi
+            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+            echo "Auto-determined next ${IDENTIFIER} version: $NEXT"
+          fi
   # Extract PR number from release tag (for auto-promotion)
   get-pr-number:
     name: Get PR Number
@@ -327,7 +569,7 @@ jobs:
 
   promote:
     name: Promote PR Image
-    needs: [get-pr-number]
+    needs: [get-pr-number, validate-version]
     if: always() && (inputs.promote_pr_number != '' || needs.get-pr-number.outputs.pr_number != '')
     runs-on: ${{ inputs.runner }}
     outputs:
@@ -340,6 +582,7 @@ jobs:
       packages: write
     env:
       PR_NUMBER: ${{ inputs.promote_pr_number || needs.get-pr-number.outputs.pr_number }}
+      VALIDATED_VERSION: ${{ needs.validate-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -365,6 +608,14 @@ jobs:
           VERSION="latest"
           EVENT_NAME="${{ github.event_name }}"
           REF="${{ github.ref }}"
+
+          # Use validated version from validate-version job if available
+          if [[ -n "$VALIDATED_VERSION" ]]; then
+            VERSION="$VALIDATED_VERSION"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Using validated version: ${VERSION}"
+            exit 0
+          fi
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]] && [[ -n "${{ github.event.inputs.version || '' }}" ]]; then
             VERSION="${{ github.event.inputs.version }}"
@@ -514,7 +765,7 @@ jobs:
 
   build:
     name: Build and Push with Docker Bake
-    needs: [get-pr-number, promote]
+    needs: [get-pr-number, promote, validate-version]
     if: |
       always() && (
         (github.event_name != 'pull_request' && inputs.promote_pr_number == '' && !(github.event_name == 'release' && inputs.auto_promote_on_release))
@@ -529,6 +780,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    env:
+      VALIDATED_VERSION: ${{ needs.validate-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -559,6 +812,14 @@ jobs:
           VERSION="latest"
           EVENT_NAME="${{ github.event_name }}"
           REF="${{ github.ref }}"
+
+          # Use validated version from validate-version job if available
+          if [[ -n "$VALIDATED_VERSION" ]]; then
+            VERSION="$VALIDATED_VERSION"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Using validated version: ${VERSION}"
+            exit 0
+          fi
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]] && [[ -n "${{ github.event.inputs.version || '' }}" ]]; then
             VERSION="${{ github.event.inputs.version }}"

--- a/.github/workflows/kustomize-ci.yaml
+++ b/.github/workflows/kustomize-ci.yaml
@@ -17,7 +17,7 @@ on:
         type: string
         description: 'Kustomize version to use'
         required: false
-        default: 'latest'
+        default: '5.8.1'
       kubernetes_version:
         type: string
         description: 'Kubernetes version for validation (e.g., 1.32.0)'
@@ -86,9 +86,14 @@ jobs:
 
       - name: 'Setup Kustomize'
         if: steps.filter.outputs.k8s == 'true'
-        uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2.1.0
-        with:
-          kustomize-version: ${{ inputs.kustomize_version }}
+        run: |
+          KUSTOMIZE_VERSION="${{ inputs.kustomize_version }}"
+          echo "Installing kustomize v${KUSTOMIZE_VERSION}"
+          curl -sLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          tar xzf "kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          sudo mv kustomize /usr/local/bin/
+          rm "kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          kustomize version
 
       - name: 'Setup Python for yamllint'
         if: steps.filter.outputs.k8s == 'true' && !inputs.skip_yamllint

--- a/.github/workflows/kustomize-ci.yaml
+++ b/.github/workflows/kustomize-ci.yaml
@@ -54,11 +54,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Check if there are changes in the k8s directory
-  check-changes:
+  # Lint and validate Kustomize files
+  lint:
     runs-on: ${{ inputs.runner }}
-    outputs:
-      k8s_changed: ${{ steps.filter.outputs.k8s }}
     steps:
       - name: 'Checkout'
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -68,7 +66,6 @@ jobs:
       - name: 'Normalize k8s directory path'
         id: normalize-path
         run: |
-          # Remove leading ./ from path for dorny/paths-filter compatibility
           K8S_DIR="${{ inputs.k8s_directory }}"
           K8S_DIR="${K8S_DIR#./}"
           echo "normalized_path=${K8S_DIR}" >> "$GITHUB_OUTPUT"
@@ -81,33 +78,30 @@ jobs:
             k8s:
               - '${{ steps.normalize-path.outputs.normalized_path }}/**'
 
-  # Lint and validate Kustomize files
-  lint:
-    runs-on: ${{ inputs.runner }}
-    needs: [check-changes]
-    # Only run if there are changes in the k8s directory
-    if: needs.check-changes.outputs.k8s_changed == 'true'
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: 'Exit early if no changes'
+        if: steps.filter.outputs.k8s != 'true'
+        run: |
+          echo "✓ No changes detected in ${{ inputs.k8s_directory }}, skipping linting"
+          exit 0
 
       - name: 'Setup Kustomize'
+        if: steps.filter.outputs.k8s == 'true'
         uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2.1.0
         with:
           kustomize-version: ${{ inputs.kustomize_version }}
 
       - name: 'Setup Python for yamllint'
-        if: ${{ !inputs.skip_yamllint }}
+        if: steps.filter.outputs.k8s == 'true' && !inputs.skip_yamllint
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.12'
 
       - name: 'Install yamllint'
-        if: ${{ !inputs.skip_yamllint }}
+        if: steps.filter.outputs.k8s == 'true' && !inputs.skip_yamllint
         run: pip install yamllint==1.35.1
 
       - name: 'Lint YAML files'
-        if: ${{ !inputs.skip_yamllint }}
+        if: steps.filter.outputs.k8s == 'true' && !inputs.skip_yamllint
         run: |
           # yamllint can be strict; by default we allow it to fail with warnings
           # Set fail_on_yamllint: true to make this a hard failure
@@ -118,6 +112,7 @@ jobs:
           fi
 
       - name: 'Build Kustomize manifests'
+        if: steps.filter.outputs.k8s == 'true'
         id: kustomize-build
         run: |
           # Find all kustomization.yaml files and build them
@@ -136,7 +131,7 @@ jobs:
           echo "Successfully built Kustomize manifests"
 
       - name: 'Validate with kubeconform'
-        if: ${{ !inputs.skip_kubeconform }}
+        if: steps.filter.outputs.k8s == 'true' && !inputs.skip_kubeconform
         run: |
           STRICT_FLAG=""
           if [ "${{ inputs.strict_validation }}" == "true" ]; then
@@ -150,7 +145,7 @@ jobs:
             -kubernetes-version ${{ inputs.kubernetes_version }}
 
       - name: 'Validate with kube-score'
-        if: ${{ !inputs.skip_kubescore }}
+        if: steps.filter.outputs.k8s == 'true' && !inputs.skip_kubescore
         run: |
           # kube-score expects version in vN.NN format, not N.NN.N
           K8S_VERSION_SHORT=$(echo "${{ inputs.kubernetes_version }}" | cut -d. -f1-2)

--- a/examples/dependabot-autobots.yaml
+++ b/examples/dependabot-autobots.yaml
@@ -1,0 +1,16 @@
+name: Dependabot Autobots
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * *'  # Daily at 04:17 UTC
+
+jobs:
+  dependabot:
+    uses: calebsargeant/reusable-workflows/.github/workflows/dependabot-generator.yaml@a977831800ef046f28ba5d56ecb99221c5a18768 # 0.0.1
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/examples/docker-release-caller.yaml
+++ b/examples/docker-release-caller.yaml
@@ -1,0 +1,94 @@
+# Example Docker Release Caller Workflow
+#
+# This workflow calls the reusable docker-release workflow to build and publish
+# container images on release events.
+#
+# Features:
+# - Automatic PR image promotion on release (re-tags pr-<number> image)
+# - Falls back to fresh build if PR image is outdated
+# - Manual workflow dispatch for ad-hoc builds from any branch
+# - Flexible branch-to-version-type mapping (supports any number of branches):
+#   - main: stable semver (v1.2.3)
+#   - staging: release candidate (v1.2.3-rc.1)
+#   - develop: alpha (v1.2.3-alpha.1)
+#   - etc.
+
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        type: choice
+        options:
+          - main
+          - staging
+          # Add more branches as needed
+        default: 'main'
+      version:
+        description: 'Version tag (e.g., v1.0.0 for main, v1.0.0-rc.1 for staging). Leave empty to auto-increment.'
+        required: false
+        type: string
+
+jobs:
+  release:
+    uses: calebsargeant/reusable-workflows/.github/workflows/docker-release.yaml@main
+    with:
+      # Required: Set your image name
+      image_name: my-app
+
+      # Optional: Docker Bake configuration
+      bake_file: docker-bake.hcl
+      bake_target: default
+
+      # Optional: Target platforms
+      platforms: linux/amd64,linux/arm64
+
+      # Push to registry
+      push: true
+
+      # Only auto-promote on release events (dispatch always builds fresh)
+      auto_promote_on_release: ${{ github.event_name == 'release' }}
+
+      # Pass version from dispatch input (reusable workflow handles validation/auto-increment)
+      force_version: ${{ inputs.version || '' }}
+
+      # Branch-to-version mapping (JSON format)
+      # Supports any number of branches with different version types.
+      #
+      # Version format (opinionated):
+      #   - Stable: v{major}.{minor}.{patch} (e.g., v1.2.3)
+      #   - Prerelease: v{major}.{minor}.{patch}-{identifier}.{number} (e.g., v1.2.3-rc.1)
+      #
+      # Examples:
+      #   Two branches (common):
+      #     {"main": {"type": "stable"}, "staging": {"type": "prerelease", "identifier": "rc"}}
+      #
+      #   Three branches:
+      #     {"main": {"type": "stable"}, "staging": {"type": "prerelease", "identifier": "rc"}, "develop": {"type": "prerelease", "identifier": "alpha"}}
+      #
+      #   Four branches:
+      #     {"main": {"type": "stable"}, "release": {"type": "prerelease", "identifier": "rc"}, "staging": {"type": "prerelease", "identifier": "beta"}, "develop": {"type": "prerelease", "identifier": "alpha"}}
+      #
+      version_branch_mapping: '{"main": {"type": "stable"}, "staging": {"type": "prerelease", "identifier": "rc"}}'
+
+      # Optional: Custom registry (defaults to ghcr.io)
+      # registry: ghcr.io
+
+      # Optional: Custom runner
+      # runner: ubuntu-latest
+
+      # Optional: Generate SBOM
+      # enable_sbom: true
+
+      # Optional: Additional build variables
+      # buildx_vars: |
+      #   MY_VAR=value
+      #   ANOTHER_VAR=value2
+
+    secrets: inherit
+

--- a/template/docker-release-caller.yaml.jinja
+++ b/template/docker-release-caller.yaml.jinja
@@ -1,0 +1,35 @@
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        type: choice
+        options:
+{%- for branch in version_branch_mapping | default({'main': {'type': 'stable'}}) | dictsort %}
+          - {{ branch[0] }}
+{%- endfor %}
+        default: '{{ stable_branch | default('main') }}'
+      version:
+        description: 'Version tag. Leave empty to auto-increment.'
+        required: false
+        type: string
+
+jobs:
+  release:
+    uses: {{ reusable_workflows_repo }}/.github/workflows/docker-release.yaml@{{ reusable_workflows_ref }}
+    with:
+      image_name: {{ image_name | default('${{ github.event.repository.name }}') }}
+      bake_file: {{ bake_file | default('docker-bake.hcl') }}
+      bake_target: {{ bake_target | default('default') }}
+      platforms: {{ platforms | default('linux/amd64,linux/arm64') }}
+      push: true
+      auto_promote_on_release: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
+      force_version: {% raw %}${{ inputs.version || '' }}{% endraw %}
+      version_branch_mapping: '{{ version_branch_mapping | default('{"main": {"type": "stable"}}') | tojson }}'
+    secrets: inherit
+


### PR DESCRIPTION
This pull request introduces significant improvements to the Docker CI and release GitHub Actions workflows. The main focus is on enhancing path filtering for container builds and adding robust, branch-aware version validation and auto-incrementing logic for Docker releases. These changes make the workflows more flexible, maintainable, and suitable for complex branching/versioning strategies.

**Key changes:**

### Docker CI Workflow Improvements
- **Enhanced Path Filtering for Container Builds:**  
  The `container_paths` input now uses a more explicit, extensive list of file patterns (with `- ` prefix) to trigger container builds, ensuring that only relevant changes initiate builds. This replaces the previous broad globs and exclusions with a curated list of common Docker- and language-related files.
- **Workflow Structure Simplification:**  
  The separate `check-changes` job is removed. Instead, the main `ci-build` job directly handles change detection, outputting whether the build should be skipped and gating subsequent steps on the presence of relevant changes. [[1]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74L82-R192) [[2]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74L122-R219)
- **Conditional Step Execution:**  
  All build-related steps (QEMU setup, Buildx setup, Docker login, version/image setup, and Docker Bake) now run only if container-related files have changed, reducing unnecessary job executions. [[1]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74L122-R219) [[2]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74L155-R236) [[3]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74R250) [[4]](diffhunk://#diff-6352dd3f36d496bc463e075660a1d979974fb78605b838d7cffd38e79fb9fe74R262-R276)

### Docker Release Workflow Enhancements
- **Branch-Aware Version Validation and Auto-Incrementing:**  
  Introduces a `version_branch_mapping` input, allowing maintainers to define how branches map to version types (stable/prerelease) and identifiers (rc, beta, alpha, etc.). The new `validate-version` job parses this mapping, validates provided versions, and can auto-determine the next version based on branch and existing tags. This supports complex release flows and enforces consistent versioning. [[1]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R108-R134) [[2]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R148-R369)
- **Workflow Integration of Version Validation:**  
  The validated/auto-determined version is now used throughout the promote and build jobs, ensuring consistency and correctness in image tagging regardless of how the workflow is triggered. [[1]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540L330-R572) [[2]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R585) [[3]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R612-R619) [[4]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540L517-R768) [[5]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R783-R784) [[6]](diffhunk://#diff-db56167851b2143359151cc30a7c672cff85bd15f7051a2580cc42792b162540R816-R823)