### PR TITLE
fix: update security scan documentation and workflow to handle option…

### DIFF
--- a/.github/workflows/README-security-scan.md
+++ b/.github/workflows/README-security-scan.md
@@ -103,9 +103,9 @@ jobs:
 | `trivy_severity` | Severity levels | `CRITICAL,HIGH` |
 | `trivy_exit_code` | Exit code on findings | `1` (fail) |
 | `trivy_ignore_unfixed` | Ignore unfixed CVEs | `true` |
-| `trivyignore_file` | Path to .trivyignore | `.trivyignore` |
-| `gitleaks_baseline` | Path to TruffleHog exclude file | `''` |
-| `semgrep_baseline` | Path to .semgrepignore | `''` |
+| `trivyignore_file` | Path to .trivyignore (only used if exists) | `.trivyignore` |
+| `gitleaks_baseline` | Path to TruffleHog exclude file (only used if exists) | `''` |
+| `semgrep_baseline` | Path to .semgrepignore (auto-detected) | `''` |
 | `enable_sast` | Enable Semgrep SAST | `true` |
 | `enable_license_scan` | Enable license scan | `false` |
 | `semgrep_config` | Semgrep rules | `p/default p/security-audit p/secrets` |
@@ -114,6 +114,8 @@ jobs:
 ## Ignoring Pre-Existing Vulnerabilities
 
 If your project has existing vulnerabilities you can't fix immediately, use baseline/ignore files to prevent new vulnerabilities while tracking known ones.
+
+> **Note:** All ignore files are **optional**. The workflow checks if each file exists before using it - missing files won't cause errors.
 
 ### Trivy (CVEs) - `.trivyignore`
 

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: true
       trivyignore_file:
-        description: 'Path to trivyignore file for whitelisting known CVEs'
+        description: 'Path to trivyignore file for whitelisting known CVEs (only used if file exists)'
         required: false
         type: string
         default: '.trivyignore'
@@ -168,6 +168,17 @@ jobs:
       # ============================================
       # CORE: Trivy Vulnerability Scan (always runs)
       # ============================================
+      - name: Check for trivyignore file
+        id: trivyignore
+        run: |
+          if [ -f "${{ inputs.trivyignore_file }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found ${{ inputs.trivyignore_file }}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No ${{ inputs.trivyignore_file }} found, skipping ignore file"
+          fi
+
       - name: Run Trivy vulnerability scanner
         if: steps.detect.outputs.any_changed == 'true'
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
@@ -178,7 +189,7 @@ jobs:
           exit-code: ${{ inputs.trivy_exit_code }}
           ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
           skip-dirs: 'node_modules,.git,vendor'
-          trivyignores: ${{ inputs.trivyignore_file }}
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore_file || '' }}
           format: 'table'
 
       - name: Trivy SARIF output
@@ -191,7 +202,7 @@ jobs:
           exit-code: '0'
           ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
           skip-dirs: 'node_modules,.git,vendor'
-          trivyignores: ${{ inputs.trivyignore_file }}
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore_file || '' }}
           format: 'sarif'
           output: 'trivy-results.sarif'
 
@@ -206,11 +217,21 @@ jobs:
       # ============================================
       # CORE: TruffleHog Secret Detection (always runs)
       # ============================================
+      - name: Check for TruffleHog exclude file
+        id: trufflehog-baseline
+        run: |
+          if [ -n "${{ inputs.gitleaks_baseline }}" ] && [ -f "${{ inputs.gitleaks_baseline }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found ${{ inputs.gitleaks_baseline }}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run TruffleHog secret detection
         if: steps.detect.outputs.any_changed == 'true'
         uses: trufflesecurity/trufflehog@afbf580a6ec37188c43b2f3f66b9169484206a2f # v3.88.27
         with:
-          extra_args: --only-verified ${{ inputs.gitleaks_baseline != '' && format('--exclude-paths={0}', inputs.gitleaks_baseline) || '' }}
+          extra_args: --only-verified ${{ steps.trufflehog-baseline.outputs.exists == 'true' && format('--exclude-paths={0}', inputs.gitleaks_baseline) || '' }}
 
       # ============================================
       # DYNAMIC: Python Security (pip-audit)


### PR DESCRIPTION
This pull request enhances the security scan workflow by making ignore/baseline files optional and ensuring the workflow checks for their existence before use. This prevents errors when these files are missing and clarifies their usage in documentation. The changes also update input descriptions and workflow logic to reflect this behavior.

**Workflow logic improvements:**

* Added steps to check for `.trivyignore` and TruffleHog exclude files before passing them to their respective scanners, ensuring they are only used if present. [[1]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fR171-R181) [[2]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fR220-R234)
* Updated scanner invocation logic (`trivyignores` and `extra_args`) to conditionally use ignore/baseline files based on their existence, preventing errors from missing files. [[1]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL181-R192) [[2]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL194-R205) [[3]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fR220-R234)

**Documentation and input clarity:**

* Clarified in `.github/workflows/README-security-scan.md` that ignore files are optional and auto-detected, and updated descriptions for relevant inputs. [[1]](diffhunk://#diff-d2d612d0a04e09adc6c67b8ffceb2d064c5414cb4699190f4f44a7a6d10ebdd9L106-R108) [[2]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL31-R31)
* Added a note to the README explaining that missing ignore files will not cause errors, improving user guidance.