### PR TITLE
Fix/ignore no trivyignore

### DIFF
--- a/.github/workflows/README-security-scan.md
+++ b/.github/workflows/README-security-scan.md
@@ -103,9 +103,9 @@ jobs:
 | `trivy_severity` | Severity levels | `CRITICAL,HIGH` |
 | `trivy_exit_code` | Exit code on findings | `1` (fail) |
 | `trivy_ignore_unfixed` | Ignore unfixed CVEs | `true` |
-| `trivyignore_file` | Path to .trivyignore | `.trivyignore` |
-| `gitleaks_baseline` | Path to TruffleHog exclude file | `''` |
-| `semgrep_baseline` | Path to .semgrepignore | `''` |
+| `trivyignore_file` | Path to .trivyignore (only used if exists) | `.trivyignore` |
+| `gitleaks_baseline` | Path to TruffleHog exclude file (only used if exists) | `''` |
+| `semgrep_baseline` | Path to .semgrepignore (auto-detected) | `''` |
 | `enable_sast` | Enable Semgrep SAST | `true` |
 | `enable_license_scan` | Enable license scan | `false` |
 | `semgrep_config` | Semgrep rules | `p/default p/security-audit p/secrets` |
@@ -114,6 +114,8 @@ jobs:
 ## Ignoring Pre-Existing Vulnerabilities
 
 If your project has existing vulnerabilities you can't fix immediately, use baseline/ignore files to prevent new vulnerabilities while tracking known ones.
+
+> **Note:** All ignore files are **optional**. The workflow checks if each file exists before using it - missing files won't cause errors.
 
 ### Trivy (CVEs) - `.trivyignore`
 

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -241,7 +241,6 @@ jobs:
         uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
         with:
           vulnerability-service: osv
-        continue-on-error: true
 
       # ============================================
       # DYNAMIC: JavaScript/Node.js Security (npm audit)
@@ -257,19 +256,18 @@ jobs:
         run: |
           if [ -f "package-lock.json" ]; then
             echo "Running npm audit..."
-            npm audit --audit-level=high || true
+            npm audit --audit-level=high
           elif [ -f "yarn.lock" ]; then
             echo "Running yarn audit..."
             npm install -g yarn
-            yarn audit --level high || true
+            yarn audit --level high
           elif [ -f "pnpm-lock.yaml" ]; then
             echo "Running pnpm audit..."
             npm install -g pnpm
-            pnpm audit --audit-level high || true
+            pnpm audit --audit-level high
           else
             echo "No lock file found, skipping audit"
           fi
-        continue-on-error: true
 
       # ============================================
       # DYNAMIC: Go Security (govulncheck)
@@ -287,7 +285,6 @@ jobs:
         with:
           go-version-input: 'stable'
           check-latest: true
-        continue-on-error: true
 
       # ============================================
       # DYNAMIC: Dockerfile Linting (Hadolint)
@@ -325,7 +322,7 @@ jobs:
         continue-on-error: true
 
       # ============================================
-      # OPTIONAL: Semgrep SAST (caller must enable)
+      # CORE: Semgrep SAST (enabled by default)
       # ============================================
       - name: Run Semgrep SAST
         if: steps.detect.outputs.any_changed == 'true' && inputs.enable_sast
@@ -333,10 +330,9 @@ jobs:
         with:
           config: ${{ inputs.semgrep_config }}
           generateSarif: '1'
-        continue-on-error: true
 
       - name: Upload Semgrep SARIF
-        if: steps.detect.outputs.any_changed == 'true' && inputs.enable_sast
+        if: steps.detect.outputs.any_changed == 'true' && inputs.enable_sast && always()
         uses: github/codeql-action/upload-sarif@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3.32.3
         with:
           sarif_file: 'semgrep.sarif'
@@ -355,11 +351,10 @@ jobs:
           skip_check: ${{ inputs.checkov_skip_checks }}
           output_format: sarif
           output_file_path: checkov-results.sarif
-          soft_fail: true
-        continue-on-error: true
+          soft_fail: false
 
       - name: Upload Checkov SARIF
-        if: steps.detect.outputs.any_changed == 'true' && steps.detect.outputs.iac == 'true'
+        if: steps.detect.outputs.any_changed == 'true' && steps.detect.outputs.iac == 'true' && always()
         uses: github/codeql-action/upload-sarif@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3.32.3
         with:
           sarif_file: 'checkov-results.sarif'

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: true
       trivyignore_file:
-        description: 'Path to trivyignore file for whitelisting known CVEs'
+        description: 'Path to trivyignore file for whitelisting known CVEs (only used if file exists)'
         required: false
         type: string
         default: '.trivyignore'
@@ -168,6 +168,17 @@ jobs:
       # ============================================
       # CORE: Trivy Vulnerability Scan (always runs)
       # ============================================
+      - name: Check for trivyignore file
+        id: trivyignore
+        run: |
+          if [ -f "${{ inputs.trivyignore_file }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found ${{ inputs.trivyignore_file }}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No ${{ inputs.trivyignore_file }} found, skipping ignore file"
+          fi
+
       - name: Run Trivy vulnerability scanner
         if: steps.detect.outputs.any_changed == 'true'
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
@@ -178,7 +189,7 @@ jobs:
           exit-code: ${{ inputs.trivy_exit_code }}
           ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
           skip-dirs: 'node_modules,.git,vendor'
-          trivyignores: ${{ inputs.trivyignore_file }}
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore_file || '' }}
           format: 'table'
 
       - name: Trivy SARIF output
@@ -191,7 +202,7 @@ jobs:
           exit-code: '0'
           ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
           skip-dirs: 'node_modules,.git,vendor'
-          trivyignores: ${{ inputs.trivyignore_file }}
+          trivyignores: ${{ steps.trivyignore.outputs.exists == 'true' && inputs.trivyignore_file || '' }}
           format: 'sarif'
           output: 'trivy-results.sarif'
 
@@ -206,11 +217,21 @@ jobs:
       # ============================================
       # CORE: TruffleHog Secret Detection (always runs)
       # ============================================
+      - name: Check for TruffleHog exclude file
+        id: trufflehog-baseline
+        run: |
+          if [ -n "${{ inputs.gitleaks_baseline }}" ] && [ -f "${{ inputs.gitleaks_baseline }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found ${{ inputs.gitleaks_baseline }}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run TruffleHog secret detection
         if: steps.detect.outputs.any_changed == 'true'
         uses: trufflesecurity/trufflehog@afbf580a6ec37188c43b2f3f66b9169484206a2f # v3.88.27
         with:
-          extra_args: --only-verified ${{ inputs.gitleaks_baseline != '' && format('--exclude-paths={0}', inputs.gitleaks_baseline) || '' }}
+          extra_args: --only-verified ${{ steps.trufflehog-baseline.outputs.exists == 'true' && format('--exclude-paths={0}', inputs.gitleaks_baseline) || '' }}
 
       # ============================================
       # DYNAMIC: Python Security (pip-audit)


### PR DESCRIPTION
This pull request updates the `.github/workflows/security-scan.yaml` workflow to make security scanning stricter by removing the use of `continue-on-error: true` from most jobs. This means that the workflow will now fail if any security scan finds an issue, rather than allowing the workflow to continue. Additionally, the Checkov SAST step is now set to hard fail on issues, and the Semgrep SAST step is clarified as a core part of the workflow. There are also improvements to the conditions for uploading SARIF reports.

Key changes:

**Stricter security enforcement:**
* Removed `continue-on-error: true` from Python (`pip-audit`), JavaScript (`npm audit`, `yarn audit`, `pnpm audit`), Go (`govulncheck`), and Semgrep SAST jobs, so failures in these steps will now fail the workflow. [[1]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL244) [[2]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL260-L272) [[3]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL290) [[4]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL328-R335)
* Set `soft_fail: false` for the Checkov SAST job, making it a hard failure if issues are found.

**Workflow logic and documentation updates:**
* Updated comments to indicate that Semgrep SAST is now enabled by default ("CORE") instead of being optional.
* Improved the condition for uploading SARIF reports for both Semgrep and Checkov to ensure they always run when relevant, even if previous steps fail. [[1]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL328-R335) [[2]](diffhunk://#diff-607a4798e9dd9938b8d4575d00adf257d6a98a16031cd3151def2c7986edf81fL358-R357)